### PR TITLE
Models created/updated for stakeholder & refresher training charts

### DIFF
--- a/models/intermediate/champion/champion_refresher_training_form_data.sql
+++ b/models/intermediate/champion/champion_refresher_training_form_data.sql
@@ -1,0 +1,36 @@
+-- The form data being extracted here has no case attached to it
+-- The data details out the refresher training of champions
+-- Also filter out the data that is under test location of the highest hierarchy (project_manager_test)
+
+WITH cte AS (
+    SELECT
+        district_name,
+        COALESCE(
+            NULLIF(data -> 'form' -> 'title_refresher' ->> 'CH_attended_refresher', ''),
+            null
+        )::INTEGER AS no_of_champions_attended_refresher,
+        COALESCE(
+            NULLIF(
+                data -> 'form' -> 'title_refresher' ->> 'CH_invited_refresher', ''
+            ),
+            null
+        )::INTEGER AS no_of_champions_invited_refresher,
+        COALESCE(
+            NULLIF(
+                data -> 'form' -> 'title_refresher' ->> 'batch_refresher', ''
+            ),
+            null
+        )::INTEGER AS refresher_training_batch,
+        data -> 'form' -> 'meta' ->> 'userID' AS user_id,
+        data -> 'form' -> 'meta' ->> 'username' AS username,
+        data -> 'form' -> 'title_refresher' ->> 'date_refresher' AS refresher_training_date
+
+    FROM {{ ref('champion_refresher_training_form_merged') }}
+)
+
+SELECT
+    cte.*,
+    cfs.full_name AS community_facilitator_name,
+    cfs.username AS community_facilitator_username
+FROM cte
+{{ fetch_org_hierarchy(cte, start_role = 'cf', remove_test_entries = 'yes') }}

--- a/models/prod/champion/champion_refresher_training.sql
+++ b/models/prod/champion/champion_refresher_training.sql
@@ -1,0 +1,7 @@
+with champion_refresher_training as (
+    SELECT * FROM {{ ref('champion_refresher_training_form_data') }}
+)
+
+SELECT
+    *
+FROM champion_refresher_training

--- a/models/prod/stakeholder/stakeholder_survey_data.sql
+++ b/models/prod/stakeholder/stakeholder_survey_data.sql
@@ -1,0 +1,37 @@
+with cte as (
+    SELECT
+        {{ dbt_utils.star(from=ref('stakeholders_form_merged'), except=["data"]) }}, -- metafields
+        COALESCE(
+            NULLIF(data -> 'form' -> 'commcare_usercase' -> 'case' -> 'update' ->> 'name_of_the_stakeholder', ''), data -> 'form' -> 'stakeholder_form' ->> 'name_of_the_stakeholder'
+        ) AS name_of_the_stakeholder,
+        COALESCE(
+            NULLIF(data -> 'form' -> 'commcare_usercase' -> 'case' -> 'update' ->> 'date_of_visit_to_stakeholder', ''), data -> 'form' -> 'stakeholder_form' ->> 'date_of_visit_to_stakeholder'
+        ) AS date_of_visit_to_stakeholder,
+        COALESCE(
+            NULLIF(data -> 'form' -> 'commcare_usercase' -> 'case' -> 'update' ->> 'designation_of_the_stakeholder', ''), data -> 'form' -> 'stakeholder_form' ->> 'designation_of_the_stakeholder'
+        ) AS designation_of_the_stakeholder,
+        COALESCE(
+            NULLIF(data -> 'form' -> 'commcare_usercase' -> 'case' -> 'update' ->> 'what_are_the_points_discussed_in_stakeholder_meeting', ''), data -> 'form' -> 'stakeholder_form' ->> 'what_are_the_points_discussed_in_stakeholder_meeting'
+        ) AS what_are_the_points_discussed_in_stakeholder_meeting
+
+    FROM {{ ref('stakeholders_form_merged') }}
+    
+)
+
+SELECT
+    cte.*,
+    CASE cte.designation_of_the_stakeholder
+        WHEN 'phc_doctor' THEN 'PHC Doctor'
+        WHEN 'phc_nurse' THEN 'PHC Nurse'
+        WHEN 'phc_other_staff' THEN 'PHC other staff'
+        WHEN 'asha_worker' THEN 'ASHA worker'
+        WHEN 'anaganwadi_worker' THEN 'Anganwadi worker'
+        WHEN 'sarpanch' THEN 'Sarpanch'
+        WHEN 'upsanpanch' THEN 'Upsarpanch'
+        WHEN 'influencial_person_in_the_village' THEN 'Influential person in the village'
+        WHEN 'other_NGO_staff' THEN 'NGO staff'
+        WHEN 'other' THEN 'Other'
+        ELSE NULL
+    END AS designation_of_the_stakeholder_display
+FROM cte
+

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -17,6 +17,9 @@ sources:
     - name: film_survey
       identifier: Film_survey
       description: This table contains the details of the film survey conducted in the Mehsana district
+    - name: stakeholder_form
+      identifier: Stakeholders_form
+      description: This table contains the details of the stakeholders involved in the Mehsana district
 - name: patan
   schema: staging_patan
   tables:
@@ -34,6 +37,9 @@ sources:
     - name: film_survey
       identifier: Film_survey
       description: This table contains the details of the film survey conducted in the Patan district
+    - name: stakeholder_form
+      identifier: Stakeholders_form
+      description: This table contains the details of the stakeholders involved in the Patan district
 - name: sabarkantha
   schema: staging_sabarkantha
   tables:
@@ -51,6 +57,9 @@ sources:
     - name: film_survey
       identifier: Film_survey
       description: This table contains the details of the film survey conducted in the Sabarkantha district
+    - name: stakeholder_form
+      identifier: Stakeholders_form
+      description: This table contains the details of the stakeholders involved in the Mehsana district
 - name: org
   schema: staging_org
   tables:

--- a/models/staging/stakeholder/stakeholders_form_merged.sql
+++ b/models/staging/stakeholder/stakeholders_form_merged.sql
@@ -1,0 +1,15 @@
+{% for district_name in district_names() %}
+
+    SELECT
+        *,
+        '{{ district_name }}' AS district_name
+    FROM
+        {{ source(
+            district_name,
+            'stakeholder_form'
+        ) }}
+
+    {% if not loop.last -%}
+        UNION ALL
+    {%- endif %}
+{% endfor %}


### PR DESCRIPTION
#11 

### Updated/created new models to facilitate building stakeholder occupation & champion refresher training charts

**Source: sources.yml**
>inserted source table stakeholder_form to extract from the 3 schemas.

**Model: stakeholders_form_merged**
>created model in staging layer to collate form data from the 3 schemas corresponding to the 3 program districts

**Model: stakeholder_survey_data**
>created model in prod layer to extract fields, clean & transform cols to facilitate stakeholder related charts

**Model: champion_refresher_training_form_data**
>created model in intermediate layer to extract fields from staging & clean, transform cols

**Model: champion_refresher_training**
>created model in prod layer to bring data from intermediate, for buidling charts